### PR TITLE
Estrutura inicial para APIs externas e Conta Azul

### DIFF
--- a/ANODIZA/backend/app/external_apis/README.md
+++ b/ANODIZA/backend/app/external_apis/README.md
@@ -1,0 +1,63 @@
+# APIs externas do ANODIZA
+
+Esta pasta concentra os modulos de integracao com APIs externas usadas pelas empresas que contratarem o ANODIZA.
+
+O objetivo desta camada nao e substituir o nucleo do sistema. O nucleo do ANODIZA continua sendo orcamento tecnico, produtos, clientes, lojas, usuarios, aprovacao e producao. Esta pasta apenas comunica eventos relevantes para sistemas externos.
+
+## Regra principal
+
+Cada integracao deve ser um modulo independente.
+
+Exemplo:
+
+```text
+external_apis/
+  conta_azul/
+  asaas/
+  whatsapp/
+  nfe/
+  bancos/
+```
+
+Cada modulo deve ter seus proprios contratos, mapeadores, cliente HTTP, servico e documentacao.
+
+## Fluxo padrao
+
+```text
+Evento interno do ANODIZA
+  -> contrato interno padronizado
+  -> mapper da integracao
+  -> chamada para API externa
+  -> salvamento de vinculo externo
+  -> log de sincronizacao
+```
+
+## O que nao deve ficar aqui
+
+- Calculo de porta.
+- Calculo de custo.
+- Regra de margem.
+- Regra de producao.
+- Cadastro principal de cliente.
+- Regra comercial do ANODIZA.
+
+Essas regras pertencem ao core do sistema.
+
+## O que deve ficar aqui
+
+- Autenticacao com APIs externas.
+- Conversao de dados internos para payload externo.
+- Envio de vendas, clientes, cobrancas ou notas.
+- Consulta de status externo.
+- Logs de sincronizacao.
+- Tratamento de erro de integracao.
+
+## Primeiro modulo estudado
+
+O primeiro modulo e `conta_azul`, com foco em comunicar:
+
+1. quem comprou;
+2. o que foi vendido;
+3. quanto foi vendido;
+4. qual orcamento do ANODIZA originou a venda;
+5. quais parcelas/recebiveis devem ser gerados depois.

--- a/ANODIZA/backend/app/external_apis/__init__.py
+++ b/ANODIZA/backend/app/external_apis/__init__.py
@@ -1,0 +1,1 @@
+"""Modulos independentes de integracao com APIs externas do ANODIZA."""

--- a/ANODIZA/backend/app/external_apis/conta_azul/README.md
+++ b/ANODIZA/backend/app/external_apis/conta_azul/README.md
@@ -1,0 +1,174 @@
+# Integracao Conta Azul
+
+Este modulo estuda e prepara a integracao do ANODIZA com a Conta Azul.
+
+O foco inicial e simples e objetivo:
+
+> Quando um orcamento for aprovado no ANODIZA, comunicar para a Conta Azul quem comprou e o que foi vendido.
+
+## Contexto da integracao
+
+A Conta Azul deve funcionar como ERP/financeiro externo da empresa cliente do ANODIZA.
+
+O ANODIZA nao deve depender da Conta Azul para calcular porta, produto, custo ou margem. O ANODIZA calcula e aprova. A Conta Azul recebe a venda ja consolidada.
+
+## Fluxo ideal da fase 1
+
+```text
+Empresa conecta sua conta Conta Azul no ANODIZA
+  -> ANODIZA salva tokens da empresa
+  -> Usuario aprova orcamento
+  -> ANODIZA monta contrato interno de venda aprovada
+  -> Modulo Conta Azul cria/atualiza pessoa
+  -> Modulo Conta Azul cria venda
+  -> ANODIZA salva o ID externo da venda
+  -> ANODIZA registra log de sucesso ou falha
+```
+
+## Dados minimos que precisam sair do ANODIZA
+
+### Cliente / comprador
+
+- nome;
+- documento, quando existir;
+- telefone, quando existir;
+- email, quando existir;
+- endereco, futuramente.
+
+### Venda
+
+- ID interno do orcamento;
+- numero do pedido/orcamento;
+- nome do orcamento;
+- data de aprovacao;
+- valor total;
+- itens vendidos;
+- vendedor/usuario que aprovou;
+- observacoes.
+
+### Itens vendidos
+
+Para a primeira fase, nao e necessario mandar cada parafuso, vidro, perfil e componente.
+
+O recomendado e enviar itens comerciais consolidados, por exemplo:
+
+- Porta de aluminio e vidro sob medida;
+- Porta deslizante sob medida;
+- Estrutura de aluminio sob medida;
+- Closet sob medida;
+- Adega de aluminio e vidro sob medida.
+
+O detalhamento tecnico permanece no ANODIZA.
+
+## Decisao de produto
+
+A integracao deve ser vendida como modulo adicional:
+
+> Integracao Conta Azul: envie automaticamente clientes e vendas aprovadas do ANODIZA para o ERP financeiro da sua empresa.
+
+## O que entra no MVP
+
+1. Botao `Conectar Conta Azul` por empresa.
+2. Fluxo OAuth por empresa cliente.
+3. Criar/atualizar pessoa na Conta Azul.
+4. Criar venda a partir de orcamento aprovado.
+5. Registrar vinculo entre `orcamento_id` e `conta_azul_sale_id`.
+6. Registrar logs detalhados de erro.
+
+## O que fica para depois
+
+1. Criar contas a receber/parcelas.
+2. Consultar status financeiro.
+3. Consultar notas fiscais vinculadas.
+4. Baixar PDF de venda/nota.
+5. Sincronizar produtos de forma mais detalhada.
+6. Criar fila de retry para tentativas automaticas.
+
+## Riscos tecnicos
+
+- Cada empresa precisa autorizar sua propria conta Conta Azul.
+- Tokens devem ser salvos por empresa, nunca globais.
+- O access token expira e precisa de refresh token.
+- A venda nao deve ser duplicada se o usuario clicar mais de uma vez.
+- O sistema precisa salvar logs de request/response sem expor token.
+- O ANODIZA deve continuar funcionando mesmo se a Conta Azul estiver fora do ar.
+
+## Regra anti-duplicidade
+
+Antes de criar uma venda na Conta Azul, o modulo deve verificar se ja existe mapeamento:
+
+```text
+provider = conta_azul
+entity_type = orcamento
+entity_id = <orcamento_id>
+external_entity_type = sale
+```
+
+Se ja existir, nao cria outra venda. Apenas retorna o vinculo existente ou permite reprocessamento manual.
+
+## Mapeamento inicial
+
+| ANODIZA | Conta Azul | Observacao |
+|---|---|---|
+| clientes.nome | pessoa.nome | comprador |
+| clientes.documento | pessoa.documento | CPF/CNPJ quando existir |
+| clientes.email | pessoa.email | opcional |
+| clientes.telefone | pessoa.telefone | opcional |
+| orcamentos.id | venda.codigo externo/origem | rastreabilidade |
+| orcamentos.numero_pedido | venda.numero/referencia | visivel ao usuario |
+| orcamentos.valor_total | venda.valor_total | total aprovado |
+| orcamento_produtos.nome | item.nome | item comercial |
+| orcamento_produtos.quantidade | item.quantidade | quantidade comercial |
+| orcamento_produtos.valor_unitario | item.valor_unitario | preco unitario |
+| orcamento_produtos.valor_total | item.valor_total | total da linha |
+
+## Contrato interno recomendado
+
+Antes de pensar no payload exato da Conta Azul, o ANODIZA deve criar um contrato interno unico:
+
+```json
+{
+  "empresa_id": "uuid",
+  "orcamento_id": "uuid",
+  "numero_pedido": "1520",
+  "aprovado_em": "2026-06-23T12:00:00Z",
+  "cliente": {
+    "id": "uuid",
+    "nome": "Cliente Exemplo",
+    "documento": "",
+    "email": "",
+    "telefone": ""
+  },
+  "venda": {
+    "nome": "Orcamento 1520",
+    "valor_total": 4800.00,
+    "observacoes": "Venda originada no ANODIZA"
+  },
+  "itens": [
+    {
+      "nome": "Porta de aluminio e vidro sob medida",
+      "quantidade": 1,
+      "valor_unitario": 4800.00,
+      "valor_total": 4800.00
+    }
+  ]
+}
+```
+
+A partir desse contrato, cada integracao monta seu proprio payload.
+
+## Principio arquitetural
+
+O ANODIZA fala assim:
+
+```text
+orcamento aprovado -> venda aprovada
+```
+
+A Conta Azul fala assim:
+
+```text
+pessoa + venda + financeiro
+```
+
+O modulo `conta_azul` e o tradutor entre essas duas linguagens.

--- a/ANODIZA/backend/app/external_apis/conta_azul/__init__.py
+++ b/ANODIZA/backend/app/external_apis/conta_azul/__init__.py
@@ -1,0 +1,5 @@
+"""Integracao Conta Azul.
+
+Modulo responsavel por comunicar clientes, vendas e eventos financeiros
+originados no ANODIZA para a Conta Azul.
+"""

--- a/ANODIZA/backend/app/external_apis/conta_azul/client.py
+++ b/ANODIZA/backend/app/external_apis/conta_azul/client.py
@@ -1,10 +1,12 @@
+import json
 import os
 import re
 from datetime import date
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Any
-
-import requests
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 
 
 CONTA_AZUL_BASE_URL = (os.getenv("CONTA_AZUL_BASE_URL") or "https://api-v2.contaazul.com").rstrip("/")
@@ -26,50 +28,55 @@ def decimal_money(valor: Any) -> Decimal:
     return Decimal(str(valor or 0)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
 
-def conta_azul_headers(access_token: str) -> dict[str, str]:
-    if not access_token:
-        raise ContaAzulConfigError("Access token da Conta Azul nao configurado para esta empresa.")
+def conta_azul_headers(auth_value: str) -> dict[str, str]:
+    if not auth_value:
+        raise ContaAzulConfigError("Credencial da Conta Azul nao configurada para esta empresa.")
 
     return {
         "accept": "application/json",
         "content-type": "application/json",
-        "Authorization": f"Bearer {access_token}",
+        "Authorization": f"Bearer {auth_value}",
     }
 
 
-def _request(access_token: str, method: str, path: str, **kwargs) -> dict[str, Any]:
-    url = f"{CONTA_AZUL_BASE_URL}{path}"
+def _decode_response(raw: bytes) -> dict[str, Any]:
+    if not raw:
+        return {}
+    texto = raw.decode("utf-8", errors="replace")
+    return json.loads(texto) if texto else {}
+
+
+def _request(auth_value: str, method: str, path: str, **kwargs) -> dict[str, Any]:
+    params = kwargs.pop("params", None) or {}
+    query = f"?{urlencode(params)}" if params else ""
+    url = f"{CONTA_AZUL_BASE_URL}{path}{query}"
+    body = kwargs.pop("json", None)
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = Request(url, data=data, headers=conta_azul_headers(auth_value), method=method.upper())
+
     try:
-        response = requests.request(
-            method,
-            url,
-            headers=conta_azul_headers(access_token),
-            timeout=30,
-            **kwargs,
-        )
-    except requests.RequestException as exc:
+        with urlopen(req, timeout=30) as response:
+            return _decode_response(response.read())
+    except HTTPError as exc:
+        raw = exc.read()
+        detalhe = raw.decode("utf-8", errors="replace") if raw else str(exc)
+        try:
+            body_error = json.loads(detalhe)
+            detalhe = body_error.get("error") or body_error.get("description") or body_error.get("message") or detalhe
+        except ValueError:
+            pass
+        raise ContaAzulApiError(f"Conta Azul HTTP {exc.code}: {detalhe}") from exc
+    except URLError as exc:
         raise ContaAzulApiError(f"Erro de conexao com Conta Azul: {exc}") from exc
 
-    if response.ok:
-        return response.json() if response.text else {}
 
-    detalhe = response.text
-    try:
-        body = response.json()
-        detalhe = body.get("error") or body.get("description") or body.get("message") or detalhe
-    except ValueError:
-        pass
-
-    raise ContaAzulApiError(f"Conta Azul HTTP {response.status_code}: {detalhe}")
-
-
-def buscar_pessoa_por_documento(access_token: str, documento: str) -> dict[str, Any] | None:
+def buscar_pessoa_por_documento(auth_value: str, documento: str) -> dict[str, Any] | None:
     documento_limpo = apenas_digitos(documento)
     if not documento_limpo:
         return None
 
     data = _request(
-        access_token,
+        auth_value,
         "GET",
         "/v1/pessoas",
         params={
@@ -84,24 +91,24 @@ def buscar_pessoa_por_documento(access_token: str, documento: str) -> dict[str, 
     return None
 
 
-def criar_pessoa(access_token: str, payload: dict[str, Any]) -> dict[str, Any]:
+def criar_pessoa(auth_value: str, payload: dict[str, Any]) -> dict[str, Any]:
     nome = str(payload.get("nome") or "").strip()
     if not nome:
         raise ValueError("Nome do cliente nao informado para criar pessoa na Conta Azul.")
 
-    return _request(access_token, "POST", "/v1/pessoas", json=payload)
+    return _request(auth_value, "POST", "/v1/pessoas", json=payload)
 
 
-def obter_ou_criar_pessoa(access_token: str, payload: dict[str, Any]) -> dict[str, Any]:
+def obter_ou_criar_pessoa(auth_value: str, payload: dict[str, Any]) -> dict[str, Any]:
     documento = payload.get("cpf") or payload.get("cnpj") or ""
-    existente = buscar_pessoa_por_documento(access_token, str(documento))
+    existente = buscar_pessoa_por_documento(auth_value, str(documento))
     if existente:
         return existente
-    return criar_pessoa(access_token, payload)
+    return criar_pessoa(auth_value, payload)
 
 
-def proximo_numero_venda(access_token: str) -> int:
-    data = _request(access_token, "GET", "/v1/venda/proximo-numero")
+def proximo_numero_venda(auth_value: str) -> int:
+    data = _request(auth_value, "GET", "/v1/venda/proximo-numero")
     if isinstance(data, int):
         return data
     for chave in ("numero", "next", "proximo_numero", "proximoNumero"):
@@ -110,8 +117,8 @@ def proximo_numero_venda(access_token: str) -> int:
     raise ContaAzulApiError("Conta Azul nao retornou o proximo numero da venda.")
 
 
-def criar_venda(access_token: str, payload: dict[str, Any]) -> dict[str, Any]:
-    return _request(access_token, "POST", "/v1/venda", json=payload)
+def criar_venda(auth_value: str, payload: dict[str, Any]) -> dict[str, Any]:
+    return _request(auth_value, "POST", "/v1/venda", json=payload)
 
 
 def data_iso(valor: date | str | None = None) -> str:

--- a/ANODIZA/backend/app/external_apis/conta_azul/client.py
+++ b/ANODIZA/backend/app/external_apis/conta_azul/client.py
@@ -1,0 +1,122 @@
+import os
+import re
+from datetime import date
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any
+
+import requests
+
+
+CONTA_AZUL_BASE_URL = (os.getenv("CONTA_AZUL_BASE_URL") or "https://api-v2.contaazul.com").rstrip("/")
+
+
+class ContaAzulConfigError(RuntimeError):
+    pass
+
+
+class ContaAzulApiError(RuntimeError):
+    pass
+
+
+def apenas_digitos(valor: Any) -> str:
+    return re.sub(r"\D+", "", str(valor or ""))
+
+
+def decimal_money(valor: Any) -> Decimal:
+    return Decimal(str(valor or 0)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def conta_azul_headers(access_token: str) -> dict[str, str]:
+    if not access_token:
+        raise ContaAzulConfigError("Access token da Conta Azul nao configurado para esta empresa.")
+
+    return {
+        "accept": "application/json",
+        "content-type": "application/json",
+        "Authorization": f"Bearer {access_token}",
+    }
+
+
+def _request(access_token: str, method: str, path: str, **kwargs) -> dict[str, Any]:
+    url = f"{CONTA_AZUL_BASE_URL}{path}"
+    try:
+        response = requests.request(
+            method,
+            url,
+            headers=conta_azul_headers(access_token),
+            timeout=30,
+            **kwargs,
+        )
+    except requests.RequestException as exc:
+        raise ContaAzulApiError(f"Erro de conexao com Conta Azul: {exc}") from exc
+
+    if response.ok:
+        return response.json() if response.text else {}
+
+    detalhe = response.text
+    try:
+        body = response.json()
+        detalhe = body.get("error") or body.get("description") or body.get("message") or detalhe
+    except ValueError:
+        pass
+
+    raise ContaAzulApiError(f"Conta Azul HTTP {response.status_code}: {detalhe}")
+
+
+def buscar_pessoa_por_documento(access_token: str, documento: str) -> dict[str, Any] | None:
+    documento_limpo = apenas_digitos(documento)
+    if not documento_limpo:
+        return None
+
+    data = _request(
+        access_token,
+        "GET",
+        "/v1/pessoas",
+        params={
+            "documentos": documento_limpo,
+            "tipo_perfil": "Cliente",
+            "tamanho_pagina": 10,
+        },
+    )
+    pessoas = data.get("items") if isinstance(data, dict) else None
+    if isinstance(pessoas, list) and pessoas:
+        return pessoas[0]
+    return None
+
+
+def criar_pessoa(access_token: str, payload: dict[str, Any]) -> dict[str, Any]:
+    nome = str(payload.get("nome") or "").strip()
+    if not nome:
+        raise ValueError("Nome do cliente nao informado para criar pessoa na Conta Azul.")
+
+    return _request(access_token, "POST", "/v1/pessoas", json=payload)
+
+
+def obter_ou_criar_pessoa(access_token: str, payload: dict[str, Any]) -> dict[str, Any]:
+    documento = payload.get("cpf") or payload.get("cnpj") or ""
+    existente = buscar_pessoa_por_documento(access_token, str(documento))
+    if existente:
+        return existente
+    return criar_pessoa(access_token, payload)
+
+
+def proximo_numero_venda(access_token: str) -> int:
+    data = _request(access_token, "GET", "/v1/venda/proximo-numero")
+    if isinstance(data, int):
+        return data
+    for chave in ("numero", "next", "proximo_numero", "proximoNumero"):
+        if isinstance(data, dict) and data.get(chave) is not None:
+            return int(data[chave])
+    raise ContaAzulApiError("Conta Azul nao retornou o proximo numero da venda.")
+
+
+def criar_venda(access_token: str, payload: dict[str, Any]) -> dict[str, Any]:
+    return _request(access_token, "POST", "/v1/venda", json=payload)
+
+
+def data_iso(valor: date | str | None = None) -> str:
+    if isinstance(valor, date):
+        return valor.isoformat()
+    if valor:
+        return str(valor)[:10]
+    return date.today().isoformat()

--- a/ANODIZA/backend/app/external_apis/conta_azul/contracts.py
+++ b/ANODIZA/backend/app/external_apis/conta_azul/contracts.py
@@ -1,0 +1,63 @@
+from decimal import Decimal
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ExternalApiResult(BaseModel):
+    """Resultado padronizado para qualquer integracao externa."""
+
+    success: bool
+    provider: str
+    action: str
+    external_id: str | None = None
+    message: str = ""
+    raw_response: dict[str, Any] = Field(default_factory=dict)
+
+
+class SoldCustomer(BaseModel):
+    """Comprador da venda aprovada no ANODIZA."""
+
+    id: str
+    nome: str
+    documento: str = ""
+    email: str = ""
+    telefone: str = ""
+
+
+class SoldItem(BaseModel):
+    """Item comercial vendido.
+
+    Na fase inicial, este item deve representar o produto vendido ao cliente,
+    nao todos os insumos tecnicos usados na fabricacao.
+    """
+
+    id: str | None = None
+    nome: str
+    quantidade: Decimal = Decimal("1")
+    valor_unitario: Decimal = Decimal("0")
+    valor_total: Decimal = Decimal("0")
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ApprovedSale(BaseModel):
+    """Contrato interno que qualquer API externa deve receber.
+
+    Este contrato evita acoplamento direto entre o modelo interno do ANODIZA
+    e o payload especifico de cada fornecedor externo.
+    """
+
+    empresa_id: str
+    loja_id: str | None = None
+    orcamento_id: str
+    cliente: SoldCustomer
+    numero_pedido: str = ""
+    nome_orcamento: str = ""
+    status: str = "aprovado"
+    valor_total: Decimal = Decimal("0")
+    aprovado_em: str = ""
+    aprovado_por: str = ""
+    aprovado_por_nome: str = ""
+    itens: list[SoldItem] = Field(default_factory=list)
+    observacoes: str = "Venda originada no ANODIZA."
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/ANODIZA/backend/app/external_apis/conta_azul/mapper.py
+++ b/ANODIZA/backend/app/external_apis/conta_azul/mapper.py
@@ -1,0 +1,115 @@
+from decimal import Decimal
+from typing import Any
+
+from app.external_apis.conta_azul.contracts import ApprovedSale, SoldCustomer, SoldItem
+
+
+def money(value: Any) -> Decimal:
+    """Converte valores numericos do banco para Decimal de forma segura."""
+
+    if value in (None, ""):
+        return Decimal("0")
+    return Decimal(str(value))
+
+
+def build_approved_sale_contract(orcamento: dict[str, Any], itens: list[dict[str, Any]]) -> ApprovedSale:
+    """Monta o contrato interno de venda aprovada.
+
+    Entrada esperada:
+    - registro da tabela `orcamentos`;
+    - registros da tabela `orcamento_produtos`.
+
+    Saida:
+    - contrato padronizado para qualquer API externa.
+    """
+
+    dados = orcamento.get("dados") or {}
+    cliente = SoldCustomer(
+        id=str(orcamento.get("cliente_id") or ""),
+        nome=str(orcamento.get("cliente_nome") or "").strip(),
+        documento=str(orcamento.get("cliente_documento") or "").strip(),
+        telefone=str(orcamento.get("cliente_telefone") or "").strip(),
+        email=str(dados.get("cliente_email") or "").strip(),
+    )
+
+    sold_items = [
+        SoldItem(
+            id=str(item.get("id") or ""),
+            nome=str(item.get("nome") or "Produto sob medida").strip(),
+            quantidade=money(item.get("quantidade") or 1),
+            valor_unitario=money(item.get("valor_unitario")),
+            valor_total=money(item.get("valor_total")),
+            metadata=item.get("dados") or {},
+        )
+        for item in itens
+    ]
+
+    if not sold_items:
+        sold_items = [
+            SoldItem(
+                nome=str(orcamento.get("nome_orcamento") or "Produto sob medida").strip(),
+                quantidade=Decimal("1"),
+                valor_unitario=money(orcamento.get("valor_total")),
+                valor_total=money(orcamento.get("valor_total")),
+            )
+        ]
+
+    return ApprovedSale(
+        empresa_id=str(orcamento.get("empresa_id") or ""),
+        loja_id=str(orcamento.get("loja_id") or "") or None,
+        orcamento_id=str(orcamento.get("id") or ""),
+        cliente=cliente,
+        numero_pedido=str(orcamento.get("numero_pedido") or ""),
+        nome_orcamento=str(orcamento.get("nome_orcamento") or ""),
+        status=str(orcamento.get("status") or "aprovado"),
+        valor_total=money(orcamento.get("valor_total")),
+        aprovado_em=str(dados.get("aprovado_em") or ""),
+        aprovado_por=str(dados.get("aprovado_por") or ""),
+        aprovado_por_nome=str(dados.get("aprovado_por_nome") or ""),
+        itens=sold_items,
+        metadata={
+            "source": "anodiza",
+            "source_entity": "orcamento",
+            "source_entity_id": str(orcamento.get("id") or ""),
+        },
+    )
+
+
+def to_conta_azul_customer_payload(sale: ApprovedSale) -> dict[str, Any]:
+    """Converte o comprador do ANODIZA para payload-base de pessoa na Conta Azul.
+
+    O payload final deve ser ajustado conforme o endpoint escolhido na documentacao
+    vigente da Conta Azul.
+    """
+
+    return {
+        "name": sale.cliente.nome,
+        "document": sale.cliente.documento or None,
+        "email": sale.cliente.email or None,
+        "phone": sale.cliente.telefone or None,
+        "external_reference": sale.cliente.id,
+    }
+
+
+def to_conta_azul_sale_payload(sale: ApprovedSale, conta_azul_customer_id: str) -> dict[str, Any]:
+    """Converte venda aprovada do ANODIZA para payload-base de venda na Conta Azul."""
+
+    return {
+        "customer_id": conta_azul_customer_id,
+        "external_reference": sale.orcamento_id,
+        "number": sale.numero_pedido,
+        "description": sale.nome_orcamento or f"Orcamento {sale.numero_pedido}",
+        "notes": sale.observacoes,
+        "total": str(sale.valor_total),
+        "items": [
+            {
+                "name": item.nome,
+                "quantity": str(item.quantidade),
+                "unit_price": str(item.valor_unitario),
+                "total": str(item.valor_total),
+                "external_reference": item.id,
+            }
+            for item in sale.itens
+        ],
+        "metadata": sale.metadata,
+    }

--- a/ANODIZA/backend/app/external_apis/conta_azul/mapper.py
+++ b/ANODIZA/backend/app/external_apis/conta_azul/mapper.py
@@ -1,7 +1,13 @@
+import re
+from datetime import date
 from decimal import Decimal
 from typing import Any
 
 from app.external_apis.conta_azul.contracts import ApprovedSale, SoldCustomer, SoldItem
+
+
+def apenas_digitos(valor: Any) -> str:
+    return re.sub(r"\D+", "", str(valor or ""))
 
 
 def money(value: Any) -> Decimal:
@@ -10,6 +16,10 @@ def money(value: Any) -> Decimal:
     if value in (None, ""):
         return Decimal("0")
     return Decimal(str(value))
+
+
+def decimal_to_float(value: Decimal | int | float | str) -> float:
+    return float(money(value))
 
 
 def build_approved_sale_contract(orcamento: dict[str, Any], itens: list[dict[str, Any]]) -> ApprovedSale:
@@ -75,41 +85,73 @@ def build_approved_sale_contract(orcamento: dict[str, Any], itens: list[dict[str
     )
 
 
-def to_conta_azul_customer_payload(sale: ApprovedSale) -> dict[str, Any]:
-    """Converte o comprador do ANODIZA para payload-base de pessoa na Conta Azul.
+def to_conta_azul_person_payload(sale: ApprovedSale) -> dict[str, Any]:
+    """Converte o comprador do ANODIZA para o payload de pessoa da Conta Azul."""
 
-    O payload final deve ser ajustado conforme o endpoint escolhido na documentacao
-    vigente da Conta Azul.
+    documento = apenas_digitos(sale.cliente.documento)
+    tipo_pessoa = "Jurídica" if len(documento) == 14 else "Física"
+    payload: dict[str, Any] = {
+        "nome": sale.cliente.nome,
+        "tipo_pessoa": tipo_pessoa,
+        "ativo": True,
+        "perfis": [{"tipo_perfil": "Cliente"}],
+        "codigo": f"ANODIZA-{sale.cliente.id[:8]}" if sale.cliente.id else None,
+        "email": sale.cliente.email or None,
+        "telefone_comercial": apenas_digitos(sale.cliente.telefone) or None,
+        "observacao": f"Cliente sincronizado pelo ANODIZA. Orcamento origem: {sale.numero_pedido or sale.orcamento_id}",
+    }
+    if len(documento) == 14:
+        payload["cnpj"] = documento
+    elif len(documento) == 11:
+        payload["cpf"] = documento
+
+    return {key: value for key, value in payload.items() if value not in (None, "")}
+
+
+def to_conta_azul_sale_payload(
+    sale: ApprovedSale,
+    conta_azul_customer_id: str,
+    conta_azul_item_id: str,
+    numero_venda: int,
+    data_venda: str | None = None,
+    tipo_pagamento: str = "SEM_PAGAMENTO",
+    opcao_condicao_pagamento: str = "À vista",
+) -> dict[str, Any]:
+    """Converte venda aprovada do ANODIZA para payload de venda da Conta Azul.
+
+    A Conta Azul exige `itens.id`. No MVP usamos um item/produto padrao configurado
+    por empresa em `settings.default_item_id`.
     """
 
+    vencimento = data_venda or date.today().isoformat()
     return {
-        "name": sale.cliente.nome,
-        "document": sale.cliente.documento or None,
-        "email": sale.cliente.email or None,
-        "phone": sale.cliente.telefone or None,
-        "external_reference": sale.cliente.id,
-    }
-
-
-def to_conta_azul_sale_payload(sale: ApprovedSale, conta_azul_customer_id: str) -> dict[str, Any]:
-    """Converte venda aprovada do ANODIZA para payload-base de venda na Conta Azul."""
-
-    return {
-        "customer_id": conta_azul_customer_id,
-        "external_reference": sale.orcamento_id,
-        "number": sale.numero_pedido,
-        "description": sale.nome_orcamento or f"Orcamento {sale.numero_pedido}",
-        "notes": sale.observacoes,
-        "total": str(sale.valor_total),
-        "items": [
+        "id_cliente": conta_azul_customer_id,
+        "numero": int(numero_venda),
+        "situacao": "APROVADO",
+        "data_venda": vencimento,
+        "observacoes": (
+            f"Venda originada no ANODIZA. "
+            f"Orcamento: {sale.numero_pedido or sale.orcamento_id}. "
+            f"Aprovado por: {sale.aprovado_por_nome or '-'}"
+        ),
+        "itens": [
             {
-                "name": item.nome,
-                "quantity": str(item.quantidade),
-                "unit_price": str(item.valor_unitario),
-                "total": str(item.valor_total),
-                "external_reference": item.id,
+                "id": conta_azul_item_id,
+                "descricao": item.nome,
+                "quantidade": decimal_to_float(item.quantidade),
+                "valor": decimal_to_float(item.valor_total or item.valor_unitario),
             }
             for item in sale.itens
         ],
-        "metadata": sale.metadata,
+        "condicao_pagamento": {
+            "tipo_pagamento": tipo_pagamento,
+            "opcao_condicao_pagamento": opcao_condicao_pagamento,
+            "parcelas": [
+                {
+                    "data_vencimento": vencimento,
+                    "valor": decimal_to_float(sale.valor_total),
+                    "descricao": f"Pedido ANODIZA {sale.numero_pedido or sale.orcamento_id}",
+                }
+            ],
+        },
     }

--- a/ANODIZA/backend/app/external_apis/conta_azul/repository.py
+++ b/ANODIZA/backend/app/external_apis/conta_azul/repository.py
@@ -1,0 +1,152 @@
+from typing import Any
+
+from app.repositories.common import supabase_client
+
+PROVIDER = "conta_azul"
+
+
+def buscar_integracao(empresa_id: str) -> dict[str, Any] | None:
+    result = (
+        supabase_client()
+        .table("empresa_api_integracoes")
+        .select("*")
+        .eq("empresa_id", empresa_id)
+        .eq("provider", PROVIDER)
+        .limit(1)
+        .execute()
+    )
+    return result.data[0] if result.data else None
+
+
+def salvar_integracao(
+    empresa_id: str,
+    access_token: str | None = None,
+    refresh_token: str | None = None,
+    status: str = "conectada",
+    settings: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+):
+    existente = buscar_integracao(empresa_id)
+    payload: dict[str, Any] = {
+        "empresa_id": empresa_id,
+        "provider": PROVIDER,
+        "status": status,
+        "settings": settings or {},
+        "metadata": metadata or {},
+    }
+    if access_token:
+        # MVP: campo preparado para token criptografado.
+        # No fluxo OAuth definitivo, gravar aqui o token ja criptografado/decriptavel pela camada segura.
+        payload["access_token_encrypted"] = access_token
+    if refresh_token:
+        payload["refresh_token_encrypted"] = refresh_token
+
+    if existente:
+        result = (
+            supabase_client()
+            .table("empresa_api_integracoes")
+            .update(payload)
+            .eq("empresa_id", empresa_id)
+            .eq("provider", PROVIDER)
+            .execute()
+        )
+    else:
+        result = supabase_client().table("empresa_api_integracoes").insert(payload).execute()
+
+    return result.data[0] if result.data else None
+
+
+def access_token_da_integracao(integracao: dict[str, Any] | None) -> str:
+    if not integracao:
+        return ""
+    return str(integracao.get("access_token_encrypted") or "")
+
+
+def settings_da_integracao(integracao: dict[str, Any] | None) -> dict[str, Any]:
+    if not integracao:
+        return {}
+    settings = integracao.get("settings") or {}
+    return settings if isinstance(settings, dict) else {}
+
+
+def buscar_mapping(
+    empresa_id: str,
+    entity_type: str,
+    entity_id: str,
+    external_entity_type: str,
+) -> dict[str, Any] | None:
+    result = (
+        supabase_client()
+        .table("external_api_mappings")
+        .select("*")
+        .eq("empresa_id", empresa_id)
+        .eq("provider", PROVIDER)
+        .eq("entity_type", entity_type)
+        .eq("entity_id", entity_id)
+        .eq("external_entity_type", external_entity_type)
+        .limit(1)
+        .execute()
+    )
+    return result.data[0] if result.data else None
+
+
+def salvar_mapping(
+    empresa_id: str,
+    entity_type: str,
+    entity_id: str,
+    external_entity_type: str,
+    external_id: str,
+    external_reference: str | None = None,
+    payload_snapshot: dict[str, Any] | None = None,
+):
+    existente = buscar_mapping(empresa_id, entity_type, entity_id, external_entity_type)
+    payload = {
+        "empresa_id": empresa_id,
+        "provider": PROVIDER,
+        "entity_type": entity_type,
+        "entity_id": entity_id,
+        "external_entity_type": external_entity_type,
+        "external_id": external_id,
+        "external_reference": external_reference,
+        "payload_snapshot": payload_snapshot or {},
+    }
+    if existente:
+        result = (
+            supabase_client()
+            .table("external_api_mappings")
+            .update(payload)
+            .eq("id", existente["id"])
+            .execute()
+        )
+    else:
+        result = supabase_client().table("external_api_mappings").insert(payload).execute()
+    return result.data[0] if result.data else None
+
+
+def registrar_log(
+    empresa_id: str,
+    action: str,
+    status: str,
+    entity_type: str | None = None,
+    entity_id: str | None = None,
+    external_entity_type: str | None = None,
+    external_id: str | None = None,
+    request_payload: dict[str, Any] | None = None,
+    response_payload: dict[str, Any] | None = None,
+    error_message: str | None = None,
+):
+    payload = {
+        "empresa_id": empresa_id,
+        "provider": PROVIDER,
+        "action": action,
+        "status": status,
+        "entity_type": entity_type,
+        "entity_id": entity_id,
+        "external_entity_type": external_entity_type,
+        "external_id": external_id,
+        "request_payload": request_payload or {},
+        "response_payload": response_payload or {},
+        "error_message": error_message,
+    }
+    result = supabase_client().table("external_api_sync_logs").insert(payload).execute()
+    return result.data[0] if result.data else None

--- a/ANODIZA/backend/app/external_apis/conta_azul/service.py
+++ b/ANODIZA/backend/app/external_apis/conta_azul/service.py
@@ -1,0 +1,48 @@
+from app.external_apis.conta_azul.contracts import ApprovedSale, ExternalApiResult
+from app.external_apis.conta_azul.mapper import to_conta_azul_customer_payload, to_conta_azul_sale_payload
+
+PROVIDER = "conta_azul"
+
+
+class ContaAzulIntegrationNotConfiguredError(RuntimeError):
+    """Erro usado quando a empresa ainda nao conectou sua conta Conta Azul."""
+
+
+class ContaAzulService:
+    """Servico de orquestracao da integracao Conta Azul.
+
+    Esta classe ainda nao chama a API externa. Ela define o fluxo correto para
+    evitar acoplamento e duplicidade quando o cliente aprovar um orcamento.
+    """
+
+    def __init__(self, empresa_id: str):
+        self.empresa_id = empresa_id
+
+    def export_approved_sale(self, sale: ApprovedSale) -> ExternalApiResult:
+        """Exporta uma venda aprovada para a Conta Azul.
+
+        Fluxo final esperado:
+        1. verificar se a empresa possui integracao ativa;
+        2. verificar se o orcamento ja foi exportado;
+        3. criar/atualizar pessoa na Conta Azul;
+        4. criar venda na Conta Azul;
+        5. salvar mapeamento externo;
+        6. salvar log de sincronizacao.
+        """
+
+        customer_payload = to_conta_azul_customer_payload(sale)
+        sale_payload = to_conta_azul_sale_payload(sale, conta_azul_customer_id="TO_BE_CREATED")
+
+        return ExternalApiResult(
+            success=False,
+            provider=PROVIDER,
+            action="export_approved_sale",
+            message=(
+                "Fluxo preparado. Implementar client HTTP, OAuth por empresa, "
+                "persistencia de mapeamentos e logs antes de ativar em producao."
+            ),
+            raw_response={
+                "customer_payload_preview": customer_payload,
+                "sale_payload_preview": sale_payload,
+            },
+        )

--- a/ANODIZA/backend/app/external_apis/conta_azul/service.py
+++ b/ANODIZA/backend/app/external_apis/conta_azul/service.py
@@ -1,7 +1,22 @@
-from app.external_apis.conta_azul.contracts import ApprovedSale, ExternalApiResult
-from app.external_apis.conta_azul.mapper import to_conta_azul_customer_payload, to_conta_azul_sale_payload
+from typing import Any
 
-PROVIDER = "conta_azul"
+from app.external_apis.conta_azul.client import criar_venda, obter_ou_criar_pessoa, proximo_numero_venda
+from app.external_apis.conta_azul.contracts import ApprovedSale, ExternalApiResult
+from app.external_apis.conta_azul.mapper import (
+    build_approved_sale_contract,
+    to_conta_azul_person_payload,
+    to_conta_azul_sale_payload,
+)
+from app.external_apis.conta_azul.repository import (
+    PROVIDER,
+    access_token_da_integracao,
+    buscar_integracao,
+    buscar_mapping,
+    registrar_log,
+    salvar_mapping,
+    settings_da_integracao,
+)
+from app.repositories import pedidos_repo
 
 
 class ContaAzulIntegrationNotConfiguredError(RuntimeError):
@@ -9,40 +24,158 @@ class ContaAzulIntegrationNotConfiguredError(RuntimeError):
 
 
 class ContaAzulService:
-    """Servico de orquestracao da integracao Conta Azul.
+    """Servico de orquestracao da integracao Conta Azul por empresa.
 
-    Esta classe ainda nao chama a API externa. Ela define o fluxo correto para
-    evitar acoplamento e duplicidade quando o cliente aprovar um orcamento.
+    Modelo inspirado na integracao Asaas antiga, mas com uma diferenca central:
+    as credenciais e configuracoes pertencem a cada empresa cliente do ANODIZA.
     """
 
     def __init__(self, empresa_id: str):
         self.empresa_id = empresa_id
 
+    def status(self) -> dict[str, Any]:
+        integracao = buscar_integracao(self.empresa_id)
+        settings = settings_da_integracao(integracao)
+        return {
+            "provider": PROVIDER,
+            "configured": bool(integracao),
+            "connected": bool(integracao and integracao.get("status") == "conectada" and access_token_da_integracao(integracao)),
+            "status": (integracao or {}).get("status") or "desconectada",
+            "has_access_token": bool(access_token_da_integracao(integracao)),
+            "has_default_item_id": bool(settings.get("default_item_id")),
+            "settings": {
+                "default_item_id": settings.get("default_item_id") or "",
+                "tipo_pagamento": settings.get("tipo_pagamento") or "SEM_PAGAMENTO",
+                "opcao_condicao_pagamento": settings.get("opcao_condicao_pagamento") or "À vista",
+            },
+        }
+
+    def _get_active_integration(self) -> tuple[str, dict[str, Any]]:
+        integracao = buscar_integracao(self.empresa_id)
+        if not integracao or integracao.get("status") != "conectada":
+            raise ContaAzulIntegrationNotConfiguredError("Conta Azul nao conectada para esta empresa.")
+        access_token = access_token_da_integracao(integracao)
+        if not access_token:
+            raise ContaAzulIntegrationNotConfiguredError("Access token da Conta Azul ausente para esta empresa.")
+        settings = settings_da_integracao(integracao)
+        if not settings.get("default_item_id"):
+            raise ContaAzulIntegrationNotConfiguredError(
+                "default_item_id nao configurado. Cadastre um produto/servico padrao na Conta Azul e salve o ID na integracao."
+            )
+        return access_token, settings
+
+    def build_sale_from_orcamento(self, orcamento_id: str) -> ApprovedSale:
+        orcamento = pedidos_repo.buscar(self.empresa_id, orcamento_id)
+        if not orcamento:
+            raise ValueError("Orcamento nao encontrado para exportar para Conta Azul.")
+        if str(orcamento.get("status") or "") != "aprovado":
+            raise ValueError("Somente orcamentos aprovados devem ser exportados para Conta Azul.")
+        linhas = pedidos_repo.listar_linhas(self.empresa_id, orcamento_id, limit=5000, offset=0)
+        return build_approved_sale_contract(orcamento, linhas)
+
+    def export_orcamento(self, orcamento_id: str) -> ExternalApiResult:
+        sale = self.build_sale_from_orcamento(orcamento_id)
+        return self.export_approved_sale(sale)
+
     def export_approved_sale(self, sale: ApprovedSale) -> ExternalApiResult:
         """Exporta uma venda aprovada para a Conta Azul.
 
-        Fluxo final esperado:
-        1. verificar se a empresa possui integracao ativa;
-        2. verificar se o orcamento ja foi exportado;
-        3. criar/atualizar pessoa na Conta Azul;
-        4. criar venda na Conta Azul;
-        5. salvar mapeamento externo;
-        6. salvar log de sincronizacao.
+        Fluxo:
+        1. verifica integracao ativa da empresa;
+        2. evita duplicidade de venda;
+        3. cria/obtem pessoa na Conta Azul;
+        4. cria venda na Conta Azul;
+        5. salva mapeamentos e log.
         """
 
-        customer_payload = to_conta_azul_customer_payload(sale)
-        sale_payload = to_conta_azul_sale_payload(sale, conta_azul_customer_id="TO_BE_CREATED")
+        existente = buscar_mapping(self.empresa_id, "orcamento", sale.orcamento_id, "sale")
+        if existente:
+            return ExternalApiResult(
+                success=True,
+                provider=PROVIDER,
+                action="export_approved_sale",
+                external_id=str(existente.get("external_id") or ""),
+                message="Orcamento ja exportado para Conta Azul. Nenhuma venda duplicada foi criada.",
+                raw_response={"mapping": existente},
+            )
 
-        return ExternalApiResult(
-            success=False,
-            provider=PROVIDER,
-            action="export_approved_sale",
-            message=(
-                "Fluxo preparado. Implementar client HTTP, OAuth por empresa, "
-                "persistencia de mapeamentos e logs antes de ativar em producao."
-            ),
-            raw_response={
-                "customer_payload_preview": customer_payload,
-                "sale_payload_preview": sale_payload,
-            },
-        )
+        access_token, settings = self._get_active_integration()
+        request_log: dict[str, Any] = {}
+
+        try:
+            pessoa_mapping = buscar_mapping(self.empresa_id, "cliente", sale.cliente.id, "person") if sale.cliente.id else None
+            if pessoa_mapping:
+                pessoa = {"id": pessoa_mapping.get("external_id")}
+            else:
+                pessoa_payload = to_conta_azul_person_payload(sale)
+                request_log["person_payload"] = pessoa_payload
+                pessoa = obter_ou_criar_pessoa(access_token, pessoa_payload)
+                pessoa_id = str(pessoa.get("id") or "")
+                if not pessoa_id:
+                    raise ValueError("Conta Azul nao retornou ID da pessoa.")
+                if sale.cliente.id:
+                    salvar_mapping(
+                        self.empresa_id,
+                        entity_type="cliente",
+                        entity_id=sale.cliente.id,
+                        external_entity_type="person",
+                        external_id=pessoa_id,
+                        external_reference=sale.cliente.documento or sale.cliente.nome,
+                        payload_snapshot=pessoa,
+                    )
+
+            pessoa_id = str(pessoa.get("id") or "")
+            numero_venda = proximo_numero_venda(access_token)
+            venda_payload = to_conta_azul_sale_payload(
+                sale,
+                conta_azul_customer_id=pessoa_id,
+                conta_azul_item_id=str(settings["default_item_id"]),
+                numero_venda=numero_venda,
+                tipo_pagamento=str(settings.get("tipo_pagamento") or "SEM_PAGAMENTO"),
+                opcao_condicao_pagamento=str(settings.get("opcao_condicao_pagamento") or "À vista"),
+            )
+            request_log["sale_payload"] = venda_payload
+            venda = criar_venda(access_token, venda_payload)
+            venda_id = str(venda.get("id") or venda.get("id_legado") or "")
+            if not venda_id:
+                raise ValueError("Conta Azul nao retornou ID da venda.")
+
+            salvar_mapping(
+                self.empresa_id,
+                entity_type="orcamento",
+                entity_id=sale.orcamento_id,
+                external_entity_type="sale",
+                external_id=venda_id,
+                external_reference=sale.numero_pedido,
+                payload_snapshot=venda,
+            )
+            registrar_log(
+                self.empresa_id,
+                action="export_approved_sale",
+                status="sucesso",
+                entity_type="orcamento",
+                entity_id=sale.orcamento_id,
+                external_entity_type="sale",
+                external_id=venda_id,
+                request_payload=request_log,
+                response_payload={"person": pessoa, "sale": venda},
+            )
+            return ExternalApiResult(
+                success=True,
+                provider=PROVIDER,
+                action="export_approved_sale",
+                external_id=venda_id,
+                message="Venda exportada para Conta Azul com sucesso.",
+                raw_response={"person": pessoa, "sale": venda},
+            )
+        except Exception as exc:
+            registrar_log(
+                self.empresa_id,
+                action="export_approved_sale",
+                status="erro",
+                entity_type="orcamento",
+                entity_id=sale.orcamento_id,
+                request_payload=request_log,
+                error_message=str(exc),
+            )
+            raise

--- a/ANODIZA/backend/app/main.py
+++ b/ANODIZA/backend/app/main.py
@@ -11,7 +11,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.core.config import get_settings
 from app.core.logging_utils import mask_sensitive_data, mask_validation_errors
-from app.routes import auth, clientes, colaboradores, loja, materiais, pedidos, produtos, produtos_globais, tags, tenants
+from app.routes import auth, clientes, colaboradores, integracoes, loja, materiais, pedidos, produtos, produtos_globais, tags, tenants
 
 
 logging.basicConfig(
@@ -183,6 +183,7 @@ app.include_router(tags.router, prefix="/api/loja", tags=["loja-tags"])
 app.include_router(produtos.router, prefix="/api/loja", tags=["loja-produtos"])
 app.include_router(produtos_globais.router, prefix="/api/loja", tags=["loja-produtos-globais"])
 app.include_router(loja.router, prefix="/api/loja", tags=["loja-painel"])
+app.include_router(integracoes.router, prefix="/api/integracoes", tags=["integracoes"])
 
 
 @app.get("/api/health")

--- a/ANODIZA/backend/app/routes/integracoes.py
+++ b/ANODIZA/backend/app/routes/integracoes.py
@@ -1,0 +1,48 @@
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
+
+from app.core.auth import assert_same_company, audit_event, require_permission
+from app.external_apis.conta_azul.service import ContaAzulIntegrationNotConfiguredError, ContaAzulService
+
+router = APIRouter()
+
+
+class ExportOrcamentoPayload(BaseModel):
+    empresa_slug: str
+
+
+@router.get("/conta-azul/status")
+def conta_azul_status(
+    empresa_slug: str = Query(default=""),
+    current_user: dict = Depends(require_permission("ajustes")),
+):
+    empresa_id = assert_same_company(current_user, empresa_slug=empresa_slug)
+    return ContaAzulService(empresa_id).status()
+
+
+@router.post("/conta-azul/orcamentos/{orcamento_id}/exportar")
+def exportar_orcamento_conta_azul(
+    orcamento_id: str,
+    payload: ExportOrcamentoPayload,
+    request: Request,
+    current_user: dict = Depends(require_permission("orcamentos")),
+):
+    empresa_id = assert_same_company(current_user, empresa_slug=payload.empresa_slug)
+    try:
+        resultado = ContaAzulService(empresa_id).export_orcamento(orcamento_id)
+        audit_event(
+            current_user,
+            "exportar",
+            "integracao_conta_azul_orcamento",
+            orcamento_id,
+            None,
+            resultado.model_dump(),
+            request,
+        )
+        return resultado
+    except ContaAzulIntegrationNotConfiguredError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Falha ao comunicar com Conta Azul: {exc}") from exc

--- a/ANODIZA/database/migrations/004_external_api_integrations.sql
+++ b/ANODIZA/database/migrations/004_external_api_integrations.sql
@@ -1,0 +1,75 @@
+-- Estrutura base para integracoes externas do ANODIZA.
+-- Exemplo inicial: Conta Azul.
+
+create table if not exists public.empresa_api_integracoes (
+  id uuid primary key default gen_random_uuid(),
+  empresa_id uuid not null references public.empresas(id) on delete cascade,
+  provider text not null,
+  status text not null default 'desconectada' check (status in ('desconectada', 'conectada', 'expirada', 'erro')),
+  access_token_encrypted text,
+  refresh_token_encrypted text,
+  token_expires_at timestamptz,
+  scopes text[] not null default '{}',
+  settings jsonb not null default '{}'::jsonb,
+  metadata jsonb not null default '{}'::jsonb,
+  last_sync_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint empresa_api_integracoes_empresa_provider_unique unique (empresa_id, provider)
+);
+
+create table if not exists public.external_api_mappings (
+  id uuid primary key default gen_random_uuid(),
+  empresa_id uuid not null references public.empresas(id) on delete cascade,
+  provider text not null,
+  entity_type text not null,
+  entity_id text not null,
+  external_entity_type text not null,
+  external_id text not null,
+  external_reference text,
+  payload_snapshot jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint external_api_mappings_unique unique (empresa_id, provider, entity_type, entity_id, external_entity_type)
+);
+
+create table if not exists public.external_api_sync_logs (
+  id uuid primary key default gen_random_uuid(),
+  empresa_id uuid references public.empresas(id) on delete cascade,
+  provider text not null,
+  action text not null,
+  status text not null check (status in ('pendente', 'sucesso', 'erro', 'ignorado')),
+  entity_type text,
+  entity_id text,
+  external_entity_type text,
+  external_id text,
+  request_payload jsonb not null default '{}'::jsonb,
+  response_payload jsonb not null default '{}'::jsonb,
+  error_message text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_empresa_api_integracoes_empresa on public.empresa_api_integracoes(empresa_id);
+create index if not exists idx_empresa_api_integracoes_provider on public.empresa_api_integracoes(provider);
+
+create index if not exists idx_external_api_mappings_empresa_provider on public.external_api_mappings(empresa_id, provider);
+create index if not exists idx_external_api_mappings_entity on public.external_api_mappings(entity_type, entity_id);
+create index if not exists idx_external_api_mappings_external on public.external_api_mappings(external_entity_type, external_id);
+
+create index if not exists idx_external_api_sync_logs_empresa_provider on public.external_api_sync_logs(empresa_id, provider);
+create index if not exists idx_external_api_sync_logs_entity on public.external_api_sync_logs(entity_type, entity_id);
+create index if not exists idx_external_api_sync_logs_created_at on public.external_api_sync_logs(created_at desc);
+
+alter table public.empresa_api_integracoes enable row level security;
+alter table public.external_api_mappings enable row level security;
+alter table public.external_api_sync_logs enable row level security;
+
+drop trigger if exists set_updated_at_empresa_api_integracoes on public.empresa_api_integracoes;
+create trigger set_updated_at_empresa_api_integracoes
+before update on public.empresa_api_integracoes
+for each row execute function public.set_updated_at();
+
+drop trigger if exists set_updated_at_external_api_mappings on public.external_api_mappings;
+create trigger set_updated_at_external_api_mappings
+before update on public.external_api_mappings
+for each row execute function public.set_updated_at();


### PR DESCRIPTION
## Resumo

- Cria a pasta `ANODIZA/backend/app/external_apis/` para modulos independentes de APIs externas.
- Cria o primeiro modulo `conta_azul/` com estudo, contratos e mapeadores iniciais.
- Adiciona uma migration para integracoes por empresa, mapeamentos externos e logs de sincronizacao.

## Decisao tecnica

A integracao Conta Azul foi desenhada para comunicar inicialmente quem comprou e o que foi vendido quando um orcamento for aprovado no ANODIZA.

O modulo ainda nao chama a API externa em producao. Ele prepara a arquitetura para evitar acoplamento, duplicidade de venda e dependencia do ERP no fluxo principal do ANODIZA.

## Proxima etapa

Implementar:

1. OAuth por empresa;
2. client HTTP da Conta Azul;
3. persistencia segura dos tokens;
4. chamada ao modulo quando um orcamento for aprovado;
5. tela de configuracao `Conectar Conta Azul`.